### PR TITLE
Fix conflicts with plugins using nSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,19 @@ The only (advised) way to create a ReadyRunnableTaskBuilder from within a TaskGr
 - **No support for foreground tasks in the middle of a task chain**. If one of your tasks requires foreground execution and depends on another task that does not require it, it will not be executed in foreground. This happens because currently we do not back-propagate the foreground execution setting (but it is something planned). As a temporal fix, if a task could make a foreground task to be executed, declare the first task as a foreground task too.
 - **No support for event-driven foreground tasks** We have yet to evaluate if this is a common scenario. If you feel like this is a must-have functionality, please open an issue or comment on a existing one related to the topic. A quick workaround is to schedule the task in 1 minute by the time the event gets triggered.
 
+## Known issues
+
+### nanoSQL2
+
+If your application depends on [nanoSQL 2](https://www.npmjs.com/package/@nano-sql/adapter-sqlite-nativescript) for data persistence, you should check which database is in use (and change it, if applicable) before running a query against your database. You can do it as follows:
+
+```ts
+if (nSQL().selectedDB !== dbName) {
+  nSQL().useDatabase(dbName);
+}
+nSQL(tableName).query(...);
+```
+
 ## Plugin authors
 
 <a href="https://github.com/agonper" title="Alberto González Pérez">

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,4 +15,5 @@ declare class TaskDispatcher extends Common {
   emitEvent(eventName: string, eventData?: EventData);
 }
 export declare const taskDispatcher: TaskDispatcher;
+export { ConfigParams } from "./task-dispatcher.common";
 export {};

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-task-dispatcher",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NativeScript-based mobile background task scheduler and dispatcher",
   "main": "task-dispatcher",
   "typings": "index.d.ts",


### PR DESCRIPTION
nSQL fails to run queries when the host app or another plugin is using it too.

To avoid this issue, the database to use should be explicitly specified before executing each nSQL query.

Here's the fix along with some guidelines for plugin's users to avoid having problems with this.