### PR TITLE
Time-based scheduler minor fixes & enhancements

### DIFF
--- a/demo/app/tests/internal/persistence/planned-tasks-store.ts
+++ b/demo/app/tests/internal/persistence/planned-tasks-store.ts
@@ -22,7 +22,7 @@ describe("Planned Tasks Store", () => {
     };
     const runnableTask2: RunnableTask = {
         name: "dummyTask2",
-        startAt: new Date().getTime(),
+        startAt: Date.now(),
         interval: 60000,
         recurrent: true,
         params: { param1: "patata1", param2: "patata2" },
@@ -30,7 +30,7 @@ describe("Planned Tasks Store", () => {
     };
     const runnableTask3: RunnableTask = {
         name: "dummyTask3",
-        startAt: new Date().getTime() + 900000,
+        startAt: Date.now() + 900000,
         interval: 150000,
         recurrent: true,
         params: {},
@@ -39,7 +39,7 @@ describe("Planned Tasks Store", () => {
 
     const runnableTask4: RunnableTask = {
         name: "dummyTask4",
-        startAt: new Date().getTime() + 28e6,
+        startAt: Date.now() + 28e6,
         interval: 0,
         recurrent: false,
         params: {},
@@ -108,7 +108,7 @@ describe("Planned Tasks Store", () => {
 
         const tasks = await store.getAllSortedByNextRun();
         expect(tasks.length).toBe(4);
-        const now = new Date().getTime();
+        const now = Date.now();
         for (let i = 0; i < tasks.length - 1; i++) {
             if (tasks[i].nextRun(now) > tasks[i + 1].nextRun(now)) {
                 fail("Tasks out of order");
@@ -125,7 +125,7 @@ describe("Planned Tasks Store", () => {
 
         const tasks = await store.getAllSortedByNextRun(PlanningType.Scheduled);
         expect(tasks.length).toBe(3);
-        const now = new Date().getTime();
+        const now = Date.now();
         for (let i = 0; i < tasks.length - 1; i++) {
             if (tasks[i].nextRun(now) > tasks[i + 1].nextRun(now)) {
                 fail("Tasks out of order");

--- a/demo/app/tests/internal/persistence/planned-tasks-store.ts
+++ b/demo/app/tests/internal/persistence/planned-tasks-store.ts
@@ -1,3 +1,4 @@
+import { now } from "nativescript-task-dispatcher/internal/utils/time";
 import {
     plannedTasksDB,
     PlannedTaskAlreadyExistsError,
@@ -22,7 +23,7 @@ describe("Planned Tasks Store", () => {
     };
     const runnableTask2: RunnableTask = {
         name: "dummyTask2",
-        startAt: Date.now(),
+        startAt: now(),
         interval: 60000,
         recurrent: true,
         params: { param1: "patata1", param2: "patata2" },
@@ -30,7 +31,7 @@ describe("Planned Tasks Store", () => {
     };
     const runnableTask3: RunnableTask = {
         name: "dummyTask3",
-        startAt: Date.now() + 900000,
+        startAt: now() + 900000,
         interval: 150000,
         recurrent: true,
         params: {},
@@ -39,7 +40,7 @@ describe("Planned Tasks Store", () => {
 
     const runnableTask4: RunnableTask = {
         name: "dummyTask4",
-        startAt: Date.now() + 28e6,
+        startAt: now() + 28e6,
         interval: 0,
         recurrent: false,
         params: {},
@@ -108,9 +109,12 @@ describe("Planned Tasks Store", () => {
 
         const tasks = await store.getAllSortedByNextRun();
         expect(tasks.length).toBe(4);
-        const now = Date.now();
+        const currentMillis = now();
         for (let i = 0; i < tasks.length - 1; i++) {
-            if (tasks[i].nextRun(now) > tasks[i + 1].nextRun(now)) {
+            if (
+                tasks[i].nextRun(currentMillis) >
+                tasks[i + 1].nextRun(currentMillis)
+            ) {
                 fail("Tasks out of order");
             }
         }
@@ -125,9 +129,12 @@ describe("Planned Tasks Store", () => {
 
         const tasks = await store.getAllSortedByNextRun(PlanningType.Scheduled);
         expect(tasks.length).toBe(3);
-        const now = Date.now();
+        const currentMillis = now();
         for (let i = 0; i < tasks.length - 1; i++) {
-            if (tasks[i].nextRun(now) > tasks[i + 1].nextRun(now)) {
+            if (
+                tasks[i].nextRun(currentMillis) >
+                tasks[i + 1].nextRun(currentMillis)
+            ) {
                 fail("Tasks out of order");
             }
         }

--- a/demo/app/tests/internal/tasks/manager.ts
+++ b/demo/app/tests/internal/tasks/manager.ts
@@ -17,7 +17,7 @@ describe("Task manager", () => {
     let taskPlanner: TaskManager;
 
     const stdInterval = 60000;
-    const currentTime = new Date().getTime();
+    const currentTime = Date.now();
 
     // To be run in 30s
     const ephemeralTaskToBeRun = new PlannedTask(
@@ -230,7 +230,7 @@ describe("Task manager", () => {
 
 describe("Tasks manager next interval", () => {
     const minute = 60000;
-    const initialTime = new Date().getTime();
+    const initialTime = Date.now();
     const plannedTasksStore = createPlannedTaskStoreMock();
     let taskPlanner: TaskManager;
 

--- a/demo/app/tests/internal/tasks/manager.ts
+++ b/demo/app/tests/internal/tasks/manager.ts
@@ -8,6 +8,7 @@ import {
 import { createPlannedTaskStoreMock } from "../persistence";
 import { TaskManager } from "nativescript-task-dispatcher/internal/tasks/manager";
 import { uuid } from "nativescript-task-dispatcher/internal/utils/uuid";
+import { now } from "nativescript-task-dispatcher/internal/utils/time";
 
 describe("Task manager", () => {
     setTasks(testTasks);
@@ -17,7 +18,7 @@ describe("Task manager", () => {
     let taskPlanner: TaskManager;
 
     const stdInterval = 60000;
-    const currentTime = Date.now();
+    const currentTime = now();
 
     // To be run in 30s
     const ephemeralTaskToBeRun = new PlannedTask(
@@ -230,7 +231,7 @@ describe("Task manager", () => {
 
 describe("Tasks manager next interval", () => {
     const minute = 60000;
-    const initialTime = Date.now();
+    const initialTime = now();
     const plannedTasksStore = createPlannedTaskStoreMock();
     let taskPlanner: TaskManager;
 

--- a/demo/app/tests/internal/tasks/planner.ts
+++ b/demo/app/tests/internal/tasks/planner.ts
@@ -19,6 +19,7 @@ import { createPlannedTaskStoreMock } from "../persistence";
 import { createTaskCancelManagerMock } from ".";
 import { TaskNotFoundError } from "nativescript-task-dispatcher/internal/tasks/provider";
 import { TaskRunner } from "nativescript-task-dispatcher/internal/tasks/schedulers/immediate/instant-task-runner";
+import { now } from "nativescript-task-dispatcher/internal/utils/time";
 
 describe("Task planner", () => {
     const taskScheduler = createTaskSchedulerMock();
@@ -49,7 +50,7 @@ describe("Task planner", () => {
         .in(10)
         .build();
     const delayedTask = new RunnableTaskBuilderImpl("dummyTask", {})
-        .at(new Date(Date.now() + 3600 * 1000))
+        .at(new Date(now() + 3600 * 1000))
         .build();
 
     const immediatePlannedTask = new PlannedTask(

--- a/demo/app/tests/internal/tasks/planner.ts
+++ b/demo/app/tests/internal/tasks/planner.ts
@@ -49,7 +49,7 @@ describe("Task planner", () => {
         .in(10)
         .build();
     const delayedTask = new RunnableTaskBuilderImpl("dummyTask", {})
-        .at(new Date(new Date().getTime() + 3600 * 1000))
+        .at(new Date(Date.now() + 3600 * 1000))
         .build();
 
     const immediatePlannedTask = new PlannedTask(

--- a/demo/app/tests/internal/tasks/schedulers/time-based/android/alarm/scheduler.android.ts
+++ b/demo/app/tests/internal/tasks/schedulers/time-based/android/alarm/scheduler.android.ts
@@ -9,6 +9,10 @@ import { createPlannedTaskStoreMock } from "../../../../../persistence";
 import { RunnableTask } from "nativescript-task-dispatcher/internal/tasks/runnable-task";
 
 describe("Android Alarm Scheduler", () => {
+    if (typeof android === "undefined") {
+        return;
+    }
+
     const manager = createAlarmManagerMock();
     const watchdog = createAlarmManagerMock();
     const taskStore = createPlannedTaskStoreMock();
@@ -35,7 +39,7 @@ describe("Android Alarm Scheduler", () => {
     let equalFreqPT: PlannedTask;
 
     beforeEach(() => {
-        now = new Date().getTime();
+        now = java.lang.System.currentTimeMillis();
         dummyTask = {
             name: "dummyTask",
             startAt: -1,

--- a/demo/app/tests/internal/tasks/schedulers/time-based/android/alarm/scheduler.android.ts
+++ b/demo/app/tests/internal/tasks/schedulers/time-based/android/alarm/scheduler.android.ts
@@ -7,6 +7,7 @@ import {
 } from "nativescript-task-dispatcher/internal/tasks/planner/planned-task";
 import { createPlannedTaskStoreMock } from "../../../../../persistence";
 import { RunnableTask } from "nativescript-task-dispatcher/internal/tasks/runnable-task";
+import { now } from "nativescript-task-dispatcher/internal/utils/time";
 
 describe("Android Alarm Scheduler", () => {
     if (typeof android === "undefined") {
@@ -23,7 +24,7 @@ describe("Android Alarm Scheduler", () => {
         taskStore
     );
 
-    let now: number;
+    let currentMillis: number;
     let dummyTask: RunnableTask;
     let dummyDelayedTask: RunnableTask;
     let closeDelayedTask: RunnableTask;
@@ -39,7 +40,7 @@ describe("Android Alarm Scheduler", () => {
     let equalFreqPT: PlannedTask;
 
     beforeEach(() => {
-        now = java.lang.System.currentTimeMillis();
+        currentMillis = now();
         dummyTask = {
             name: "dummyTask",
             startAt: -1,
@@ -49,11 +50,11 @@ describe("Android Alarm Scheduler", () => {
         };
         dummyDelayedTask = {
             ...dummyTask,
-            startAt: now + 75000,
+            startAt: currentMillis + 75000,
         };
         closeDelayedTask = {
             ...dummyTask,
-            startAt: now + 30000,
+            startAt: currentMillis + 30000,
         };
         lowerFreqTask = {
             ...dummyTask,
@@ -147,7 +148,7 @@ describe("Android Alarm Scheduler", () => {
         expect(
             isLastCallCloseTo(
                 manager.set,
-                expectedDelayedTask.nextRun(now),
+                expectedDelayedTask.nextRun(currentMillis),
                 1000
             )
         ).toBeTruthy();
@@ -233,7 +234,7 @@ describe("Android Alarm Scheduler", () => {
         expect(
             isLastCallCloseTo(
                 manager.set,
-                expectedDelayedTask.nextRun(now),
+                expectedDelayedTask.nextRun(currentMillis),
                 1000
             )
         ).toBeTruthy();

--- a/demo/app/tests/internal/utils/time.ts
+++ b/demo/app/tests/internal/utils/time.ts
@@ -1,0 +1,12 @@
+import { now } from "nativescript-task-dispatcher/internal/utils/time";
+
+describe("Time utils", () => {
+    it("allows to obtain the native current time in milliseconds", () => {
+        expect(bothAreClose(now(), Date.now())).toBeTrue();
+    });
+});
+
+function bothAreClose(num1: number, num2: number): boolean {
+    const diff = Math.abs(num1 - num2);
+    return diff < 10;
+}

--- a/src/internal/persistence/planned-tasks-store.ts
+++ b/src/internal/persistence/planned-tasks-store.ts
@@ -79,7 +79,7 @@ class PlannedTaskDBStore implements PlannedTasksStore {
 
     const rows = await query.exec();
     const plannedTasks = rows.map((row) => this.plannedTaskFromRow(row));
-    const now = new Date().getTime();
+    const now = Date.now();
 
     return plannedTasks.sort((t1, t2) => t1.nextRun(now) - t2.nextRun(now));
   }

--- a/src/internal/persistence/planned-tasks-store.ts
+++ b/src/internal/persistence/planned-tasks-store.ts
@@ -2,6 +2,7 @@ import { NativeSQLite } from "@nano-sql/adapter-sqlite-nativescript";
 import { nSQL } from "@nano-sql/core/lib/index";
 import { PlannedTask, PlanningType } from "../tasks/planner/planned-task";
 import { RunnableTask } from "../tasks/runnable-task";
+import { now } from "../utils/time";
 
 const DB_NAME = "tasks-dispatcher";
 const PLANNED_TASKS_TABLE = "plannedTasks";
@@ -79,9 +80,11 @@ class PlannedTaskDBStore implements PlannedTasksStore {
 
     const rows = await query.exec();
     const plannedTasks = rows.map((row) => this.plannedTaskFromRow(row));
-    const now = Date.now();
+    const currentMillis = now();
 
-    return plannedTasks.sort((t1, t2) => t1.nextRun(now) - t2.nextRun(now));
+    return plannedTasks.sort(
+      (t1, t2) => t1.nextRun(currentMillis) - t2.nextRun(currentMillis)
+    );
   }
 
   async getAllCancelEvents(): Promise<Array<string>> {

--- a/src/internal/tasks/graph/loader.ts
+++ b/src/internal/tasks/graph/loader.ts
@@ -63,7 +63,12 @@ export class TaskGraphLoader {
     const tasksToBePrepared = await this.tasksNotReady();
     this.getLogger().info(`${tasksToBePrepared.length} are up to be prepared`);
 
-    await Promise.all(tasksToBePrepared.map((task) => task.prepare()));
+    for (let task of tasksToBePrepared) {
+      const hasYetToBePrepared = await this.hasToBePrepared(task);
+      if (hasYetToBePrepared) {
+        await task.prepare();
+      }
+    }
   }
 
   async tasksNotReady(): Promise<Array<Task>> {
@@ -116,3 +121,13 @@ export class TaskGraphLoader {
 }
 
 export const taskGraph = new TaskGraphLoader();
+
+async function hasToBePrepared(task: Task): Promise<boolean> {
+  try {
+    await task.checkIfCanRun();
+
+    return false;
+  } catch (err) {
+    return true;
+  }
+}

--- a/src/internal/tasks/manager.ts
+++ b/src/internal/tasks/manager.ts
@@ -1,6 +1,7 @@
 import { PlannedTask, PlanningType } from "./planner/planned-task";
 import { PlannedTasksStore } from "../persistence/planned-tasks-store";
 import { getTask } from "./provider";
+import { now } from "../utils/time";
 
 export class TaskManager {
   private _allTasks: Array<PlannedTask>;
@@ -9,7 +10,7 @@ export class TaskManager {
     private planningType: PlanningType,
     private plannedTasksStore: PlannedTasksStore,
     private intervalOffset: number,
-    private currentTime = Date.now()
+    private currentTime = now()
   ) {}
 
   async tasksToRun(): Promise<Array<PlannedTask>> {

--- a/src/internal/tasks/manager.ts
+++ b/src/internal/tasks/manager.ts
@@ -9,17 +9,13 @@ export class TaskManager {
     private planningType: PlanningType,
     private plannedTasksStore: PlannedTasksStore,
     private intervalOffset: number,
-    private currentTime = new Date().getTime()
+    private currentTime = Date.now()
   ) {}
 
   async tasksToRun(): Promise<Array<PlannedTask>> {
     const allTasks = await this.allTasks();
 
-    const tasksToRunNow = allTasks.filter((task) =>
-      this.determineIfTaskShouldBeRun(task)
-    );
-
-    return tasksToRunNow;
+    return allTasks.filter((task) => this.determineIfTaskShouldBeRun(task));
   }
 
   async requiresForeground(): Promise<boolean> {

--- a/src/internal/tasks/planner/planned-task.ts
+++ b/src/internal/tasks/planner/planned-task.ts
@@ -29,7 +29,7 @@ export class PlannedTask {
     public schedulerType: SchedulerType,
     task: RunnableTask,
     public id = uuid(),
-    public createdAt = new Date().getTime(),
+    public createdAt = Date.now(),
     public lastRun = -1,
     public errorCount = 0,
     public timeoutCount = 0
@@ -42,7 +42,7 @@ export class PlannedTask {
     this.cancelEvent = task.cancelEvent;
   }
 
-  nextRun(now: number = new Date().getTime()): number {
+  nextRun(now: number = Date.now()): number {
     if (this.startAt !== -1 && now < this.startAt) {
       return this.startAt - now;
     }

--- a/src/internal/tasks/planner/planned-task.ts
+++ b/src/internal/tasks/planner/planned-task.ts
@@ -1,4 +1,5 @@
 import { uuid } from "../../utils/uuid";
+import { now } from "../../utils/time";
 import { RunnableTask } from "../runnable-task";
 import { TaskParams } from "../task";
 
@@ -29,7 +30,7 @@ export class PlannedTask {
     public schedulerType: SchedulerType,
     task: RunnableTask,
     public id = uuid(),
-    public createdAt = Date.now(),
+    public createdAt = now(),
     public lastRun = -1,
     public errorCount = 0,
     public timeoutCount = 0
@@ -42,11 +43,11 @@ export class PlannedTask {
     this.cancelEvent = task.cancelEvent;
   }
 
-  nextRun(now: number = Date.now()): number {
-    if (this.startAt !== -1 && now < this.startAt) {
-      return this.startAt - now;
+  nextRun(currentTime: number = now()): number {
+    if (this.startAt !== -1 && currentTime < this.startAt) {
+      return this.startAt - currentTime;
     }
 
-    return this.interval - (now - this.lastUpdate);
+    return this.interval - (currentTime - this.lastUpdate);
   }
 }

--- a/src/internal/tasks/runners/single-task-runner.ts
+++ b/src/internal/tasks/runners/single-task-runner.ts
@@ -21,7 +21,7 @@ export class SingleTaskRunner {
     const { name, id, params } = plannedTask;
     const task = getTask(name);
 
-    await this.taskStore.updateLastRun(id, new Date().getTime());
+    await this.taskStore.updateLastRun(id, Date.now());
 
     try {
       const parameterizedTask = new ParameterizedTask(task, params, startEvent);

--- a/src/internal/tasks/runners/single-task-runner.ts
+++ b/src/internal/tasks/runners/single-task-runner.ts
@@ -4,6 +4,7 @@ import { getTask } from "../provider";
 import { Task, TaskParams } from "../task";
 import { DispatchableEvent, on, TaskDispatcherEvent, off } from "../../events";
 import { Logger, getLogger } from "../../utils/logger";
+import { now } from "../../utils/time";
 
 const FAILURE_THRESHOLD = 3;
 
@@ -21,7 +22,7 @@ export class SingleTaskRunner {
     const { name, id, params } = plannedTask;
     const task = getTask(name);
 
-    await this.taskStore.updateLastRun(id, Date.now());
+    await this.taskStore.updateLastRun(id, now());
 
     try {
       const parameterizedTask = new ParameterizedTask(task, params, startEvent);

--- a/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
@@ -11,6 +11,7 @@ import {
   DispatchableEvent,
   off,
 } from "../../../../events";
+import { now } from "../../../../utils/time";
 
 const TIMEOUT = 180000;
 const TIMEOUT_EVENT_OFFSET = 5000;
@@ -70,7 +71,7 @@ export class TaskChainRunnerService
   }
 
   private initializeExecutionWindow() {
-    this.executionStart = java.lang.System.currentTimeMillis();
+    this.executionStart = now();
     this.wakeLock.acquire(TIMEOUT);
   }
 
@@ -170,13 +171,13 @@ export class TaskChainRunnerService
   }
 
   private calculateTimeout() {
-    const now = java.lang.System.currentTimeMillis();
-    const diff = now - this.executionStart;
+    const currentMillis = now();
+    const diff = currentMillis - this.executionStart;
     return TIMEOUT - TIMEOUT_EVENT_OFFSET - diff;
   }
 
   private getExpirationTimestamp(timeout: number): number {
-    return java.lang.System.currentTimeMillis() + timeout;
+    return now() + timeout;
   }
 
   private gracefullyStop() {

--- a/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
@@ -70,7 +70,7 @@ export class TaskChainRunnerService
   }
 
   private initializeExecutionWindow() {
-    this.executionStart = new Date().getTime();
+    this.executionStart = java.lang.System.currentTimeMillis();
     this.wakeLock.acquire(TIMEOUT);
   }
 
@@ -170,13 +170,13 @@ export class TaskChainRunnerService
   }
 
   private calculateTimeout() {
-    const now = new Date().getTime();
+    const now = java.lang.System.currentTimeMillis();
     const diff = now - this.executionStart;
     return TIMEOUT - TIMEOUT_EVENT_OFFSET - diff;
   }
 
   private getExpirationTimestamp(timeout: number): number {
-    return new Date().getTime() + timeout;
+    return java.lang.System.currentTimeMillis() + timeout;
   }
 
   private gracefullyStop() {

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/manager.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/manager.android.ts
@@ -31,7 +31,7 @@ export class AndroidAlarmManager extends AbstractAlarmManager {
       this.cancel();
     }
     const alarmType = android.app.AlarmManager.RTC_WAKEUP;
-    const triggerAtMillis = new Date().getTime() + interval;
+    const triggerAtMillis = java.lang.System.currentTimeMillis() + interval;
     const pendingIntent = this.getPendingIntent();
 
     if (this.sdkVersion >= 23) {

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/manager.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/manager.android.ts
@@ -4,6 +4,7 @@ import { AbstractAlarmManager } from "../abstract-alarm-manager.android";
 import { PowerSavingsManager } from "../power-savings-manager.android";
 import { getLogger } from "../../../../../../utils/logger";
 import { planningTimestamp } from "../../../planning-timestamp";
+import { now } from "../../../../../../utils/time";
 
 const BATTERY_SAVINGS_THRESHOLD = 15 * 60 * 1000;
 
@@ -31,7 +32,7 @@ export class AndroidAlarmManager extends AbstractAlarmManager {
       this.cancel();
     }
     const alarmType = android.app.AlarmManager.RTC_WAKEUP;
-    const triggerAtMillis = java.lang.System.currentTimeMillis() + interval;
+    const triggerAtMillis = now() + interval;
     const pendingIntent = this.getPendingIntent();
 
     if (this.sdkVersion >= 23) {

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
@@ -5,6 +5,7 @@ import { plannedTasksDB } from "../../../../../../persistence/planned-tasks-stor
 import { createAlarmRunnerServiceIntent } from "../../intents.android";
 import { PlanningType } from "../../../../../planner/planned-task";
 import { Logger, getLogger } from "../../../../../../utils/logger";
+import { now } from "../../../../../../utils/time";
 
 const MIN_INTERVAL = 60000;
 
@@ -22,7 +23,7 @@ export class AlarmReceiver
     this.logger.info("Alarm triggered");
 
     this.timeOffset = 30000;
-    this.currentTime = java.lang.System.currentTimeMillis();
+    this.currentTime = now();
     this.taskManager = new TaskManager(
       PlanningType.Scheduled,
       plannedTasksDB,

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
@@ -22,7 +22,7 @@ export class AlarmReceiver
     this.logger.info("Alarm triggered");
 
     this.timeOffset = 30000;
-    this.currentTime = new Date().getTime();
+    this.currentTime = java.lang.System.currentTimeMillis();
     this.taskManager = new TaskManager(
       PlanningType.Scheduled,
       plannedTasksDB,

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
@@ -19,6 +19,7 @@ import {
 import { TaskManager } from "../../../../../manager";
 import { PlanningType } from "../../../../../planner/planned-task";
 import { Logger, getLogger } from "../../../../../../utils/logger";
+import { now } from "../../../../../../utils/time";
 
 const MIN_TIMEOUT = 60000;
 const TIMEOUT_EVENT_OFFSET = 5000;
@@ -45,7 +46,7 @@ export class AlarmRunnerService
 
     this.runsInForeground = false;
     this.timeOffset = 0;
-    this.currentTime = java.lang.System.currentTimeMillis();
+    this.currentTime = now();
 
     this.started = false;
     this.inForeground = false;
@@ -189,7 +190,7 @@ export class AlarmRunnerService
   }
 
   private getExpirationTimestamp(timeout: number): number {
-    return java.lang.System.currentTimeMillis() + timeout;
+    return now() + timeout;
   }
 
   private gracefullyStop() {

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
@@ -45,7 +45,7 @@ export class AlarmRunnerService
 
     this.runsInForeground = false;
     this.timeOffset = 0;
-    this.currentTime = new Date().getTime();
+    this.currentTime = java.lang.System.currentTimeMillis();
 
     this.started = false;
     this.inForeground = false;
@@ -189,7 +189,7 @@ export class AlarmRunnerService
   }
 
   private getExpirationTimestamp(timeout: number): number {
-    return new Date().getTime() + timeout;
+    return java.lang.System.currentTimeMillis() + timeout;
   }
 
   private gracefullyStop() {

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
@@ -1,29 +1,36 @@
+import { Logger, getLogger } from "../../../../../../utils/logger";
+import AwaitLock from "await-lock";
+
+import { AlarmManager } from "../abstract-alarm-manager.android";
+import { AndroidAlarmManager } from "./manager.android";
+import { WatchdogManager } from "../watchdog/manager.android";
+
 import {
   PlannedTasksStore,
   plannedTasksDB,
 } from "../../../../../../persistence/planned-tasks-store";
-import { AlarmManager } from "../abstract-alarm-manager.android";
-import { AndroidAlarmManager } from "./manager.android";
-import { WatchdogManager } from "../watchdog/manager.android";
 import {
   PlannedTask,
   PlanningType,
   SchedulerType,
 } from "../../../../../planner/planned-task";
 import { RunnableTask } from "../../../../../runnable-task";
-import { Logger, getLogger } from "../../../../../../utils/logger";
 
 const MIN_ALARM_INTERVAL = 60000;
 
 export class AndroidAlarmScheduler {
+  private readonly tag: string;
   private logger: Logger;
+  private lock: AwaitLock;
 
   constructor(
     private alarmManager: AlarmManager = new AndroidAlarmManager(),
     private watchdogManager: AlarmManager = new WatchdogManager(),
     private plannedTaskStore: PlannedTasksStore = plannedTasksDB
   ) {
-    this.logger = getLogger("AndroidAlarmScheduler");
+    this.tag = "AndroidAlarmScheduler";
+    this.logger = getLogger(this.tag);
+    this.lock = new AwaitLock();
   }
 
   async setup(): Promise<void> {
@@ -36,7 +43,7 @@ export class AndroidAlarmScheduler {
     if (plannedTasks.length > 0) {
       if (!this.alarmManager.alarmUp) {
         this.logger.info("Alarm was not up! Scheduling...");
-        this.alarmManager.set(this.calculateAlarmInterval(plannedTasks[0]));
+        this.alarmManager.set(calculateAlarmInterval(plannedTasks[0]));
       }
       if (!this.watchdogManager.alarmUp) {
         this.logger.info("Watchdog was not up! Initializing...");
@@ -46,11 +53,25 @@ export class AndroidAlarmScheduler {
   }
 
   async schedule(runnableTask: RunnableTask): Promise<PlannedTask> {
-    // TODO: move to index
+    await this.lock.acquireAsync();
+    const plannedTask = await this.onSchedule(runnableTask);
+    this.lock.release();
+    return plannedTask;
+  }
+
+  async cancel(id: string): Promise<void> {
+    await this.lock.acquireAsync();
+    await this.onCancel(id);
+    this.lock.release();
+  }
+
+  private async onSchedule(runnableTask: RunnableTask): Promise<PlannedTask> {
+    // TODO: move to index (verify if this remains valid)
     const possibleExisting = await this.plannedTaskStore.get(runnableTask);
     if (possibleExisting) {
       return possibleExisting;
     }
+    // Until here
     const allTasks = await this.plannedTaskStore.getAllSortedByNextRun(
       PlanningType.Scheduled
     );
@@ -64,7 +85,7 @@ export class AndroidAlarmScheduler {
       allTasks.length === 0 ||
       allTasks[0].nextRun(now) > plannedTask.nextRun(now)
     ) {
-      this.alarmManager.set(this.calculateAlarmInterval(plannedTask));
+      this.alarmManager.set(calculateAlarmInterval(plannedTask));
       if (!this.watchdogManager.alarmUp) {
         this.watchdogManager.set();
       }
@@ -75,7 +96,7 @@ export class AndroidAlarmScheduler {
     return plannedTask;
   }
 
-  async cancel(id: string) {
+  private async onCancel(id: string): Promise<void> {
     const possibleExisting = await this.plannedTaskStore.get(id);
     if (!possibleExisting) {
       return;
@@ -91,15 +112,15 @@ export class AndroidAlarmScheduler {
       allTasks[0].nextRun(now) === possibleExisting.nextRun(now) &&
       allTasks[1].nextRun(now) !== possibleExisting.nextRun(now)
     ) {
-      this.alarmManager.set(this.calculateAlarmInterval(allTasks[1]));
+      this.alarmManager.set(calculateAlarmInterval(allTasks[1]));
     }
     await this.plannedTaskStore.delete(id);
     this.logger.info(`Task with id=${id} has been canceled`);
   }
+}
 
-  private calculateAlarmInterval(plannedTask: PlannedTask): number {
-    const nextRun = plannedTask.nextRun();
+function calculateAlarmInterval(plannedTask: PlannedTask): number {
+  const nextRun = plannedTask.nextRun();
 
-    return nextRun > MIN_ALARM_INTERVAL ? nextRun : MIN_ALARM_INTERVAL;
-  }
+  return nextRun > MIN_ALARM_INTERVAL ? nextRun : MIN_ALARM_INTERVAL;
 }

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
@@ -75,7 +75,7 @@ export class AndroidAlarmScheduler {
     const allTasks = await this.plannedTaskStore.getAllSortedByNextRun(
       PlanningType.Scheduled
     );
-    const now = new Date().getTime();
+    const now = java.lang.System.currentTimeMillis();
     const plannedTask = new PlannedTask(
       PlanningType.Scheduled,
       SchedulerType.Alarm,
@@ -104,7 +104,7 @@ export class AndroidAlarmScheduler {
     const allTasks = await this.plannedTaskStore.getAllSortedByNextRun(
       PlanningType.Scheduled
     );
-    const now = new Date().getTime();
+    const now = java.lang.System.currentTimeMillis();
     if (allTasks.length === 1) {
       this.alarmManager.cancel();
       this.watchdogManager.cancel();

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/scheduler.android.ts
@@ -15,6 +15,7 @@ import {
   SchedulerType,
 } from "../../../../../planner/planned-task";
 import { RunnableTask } from "../../../../../runnable-task";
+import { now } from "../../../../../../utils/time";
 
 const MIN_ALARM_INTERVAL = 60000;
 
@@ -75,7 +76,7 @@ export class AndroidAlarmScheduler {
     const allTasks = await this.plannedTaskStore.getAllSortedByNextRun(
       PlanningType.Scheduled
     );
-    const now = java.lang.System.currentTimeMillis();
+    const currentMillis = now();
     const plannedTask = new PlannedTask(
       PlanningType.Scheduled,
       SchedulerType.Alarm,
@@ -83,7 +84,7 @@ export class AndroidAlarmScheduler {
     );
     if (
       allTasks.length === 0 ||
-      allTasks[0].nextRun(now) > plannedTask.nextRun(now)
+      allTasks[0].nextRun(currentMillis) > plannedTask.nextRun(currentMillis)
     ) {
       this.alarmManager.set(calculateAlarmInterval(plannedTask));
       if (!this.watchdogManager.alarmUp) {
@@ -104,13 +105,15 @@ export class AndroidAlarmScheduler {
     const allTasks = await this.plannedTaskStore.getAllSortedByNextRun(
       PlanningType.Scheduled
     );
-    const now = java.lang.System.currentTimeMillis();
+    const currentMillis = now();
     if (allTasks.length === 1) {
       this.alarmManager.cancel();
       this.watchdogManager.cancel();
     } else if (
-      allTasks[0].nextRun(now) === possibleExisting.nextRun(now) &&
-      allTasks[1].nextRun(now) !== possibleExisting.nextRun(now)
+      allTasks[0].nextRun(currentMillis) ===
+        possibleExisting.nextRun(currentMillis) &&
+      allTasks[1].nextRun(currentMillis) !==
+        possibleExisting.nextRun(currentMillis)
     ) {
       this.alarmManager.set(calculateAlarmInterval(allTasks[1]));
     }

--- a/src/internal/tasks/schedulers/time-based/android/alarms/watchdog/manager.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/watchdog/manager.android.ts
@@ -23,7 +23,8 @@ export class WatchdogManager extends AbstractAlarmManager {
       this.cancel();
     }
     const alarmType = android.app.AlarmManager.RTC_WAKEUP;
-    const triggerAtMillis = new Date().getTime() + WATCHDOG_INTERVAL;
+    const triggerAtMillis =
+      java.lang.System.currentTimeMillis() + WATCHDOG_INTERVAL;
     const pendingIntent = this.getPendingIntent();
 
     this.osAlarmManager.setRepeating(

--- a/src/internal/tasks/schedulers/time-based/android/alarms/watchdog/manager.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/watchdog/manager.android.ts
@@ -2,6 +2,7 @@ import { android as androidApp } from "tns-core-modules/application/application"
 import { AbstractAlarmManager } from "../abstract-alarm-manager.android";
 import { createWatchdogReceiverIntent } from "../../intents.android";
 import { getLogger } from "../../../../../../utils/logger";
+import { now } from "../../../../../../utils/time";
 
 const WATCHDOG_INTERVAL = 15 * 60 * 1000;
 
@@ -23,8 +24,7 @@ export class WatchdogManager extends AbstractAlarmManager {
       this.cancel();
     }
     const alarmType = android.app.AlarmManager.RTC_WAKEUP;
-    const triggerAtMillis =
-      java.lang.System.currentTimeMillis() + WATCHDOG_INTERVAL;
+    const triggerAtMillis = now() + WATCHDOG_INTERVAL;
     const pendingIntent = this.getPendingIntent();
 
     this.osAlarmManager.setRepeating(

--- a/src/internal/tasks/schedulers/time-based/android/intents.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/intents.android.ts
@@ -3,12 +3,10 @@ import { createLibComponentIntent } from "../../intent-tools.android";
 // TODO: Add a way to configure MainActivity reference
 // in order to support apps with custom launch activities
 export function createAppLaunchIntent(appContext: android.content.Context) {
-  const intent = createLibComponentIntent(appContext, {
+  return createLibComponentIntent(appContext, {
     pathPrefix: "com.tns",
     relativeClassPath: ".NativeScriptActivity",
   });
-
-  return intent;
 }
 
 export function createAlarmReceiverIntent(appContext: android.content.Context) {
@@ -67,7 +65,7 @@ export function unpackAlarmRunnerServiceIntent(
     timeOffset: intent.getIntExtra(ARS_TIME_OFFSET, 0),
     invocationTime: intent.getLongExtra(
       ARS_INVOCATION_TIME,
-      new Date().getTime()
+      java.lang.System.currentTimeMillis()
     ),
   };
 }

--- a/src/internal/tasks/schedulers/time-based/android/intents.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/intents.android.ts
@@ -1,4 +1,5 @@
 import { createLibComponentIntent } from "../../intent-tools.android";
+import { now } from "../../../../utils/time";
 
 // TODO: Add a way to configure MainActivity reference
 // in order to support apps with custom launch activities
@@ -63,9 +64,6 @@ export function unpackAlarmRunnerServiceIntent(
   return {
     runInForeground: intent.getBooleanExtra(ARS_RUN_IN_FOREGROUND, false),
     timeOffset: intent.getIntExtra(ARS_TIME_OFFSET, 0),
-    invocationTime: intent.getLongExtra(
-      ARS_INVOCATION_TIME,
-      java.lang.System.currentTimeMillis()
-    ),
+    invocationTime: intent.getLongExtra(ARS_INVOCATION_TIME, now()),
   };
 }

--- a/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
+++ b/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
@@ -3,6 +3,7 @@ import {
   setNumber,
   flush,
 } from "tns-core-modules/application-settings/application-settings";
+import { now } from "../../../utils/time";
 
 const PREVIOUS_PLANNING_TIMESTAMP = "PREVIOUS_PLANNING_TIMESTAMP";
 const CURRENT_PLANNING_TIMESTAMP = "CURRENT_PLANNING_TIMESTAMP";
@@ -21,7 +22,7 @@ class PlanningTimestamp {
 
   updateCurrent(): void {
     const previousCurrent = this.current;
-    const newCurrent = Date.now();
+    const newCurrent = now();
     this._previous = previousCurrent;
     this._current = newCurrent;
     setNumber(PREVIOUS_PLANNING_TIMESTAMP, previousCurrent);

--- a/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
+++ b/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
@@ -21,7 +21,7 @@ class PlanningTimestamp {
 
   updateCurrent(): void {
     const previousCurrent = this.current;
-    const newCurrent = new Date().getTime();
+    const newCurrent = Date.now();
     this._previous = previousCurrent;
     this._current = newCurrent;
     setNumber(PREVIOUS_PLANNING_TIMESTAMP, previousCurrent);

--- a/src/internal/tasks/task.ts
+++ b/src/internal/tasks/task.ts
@@ -1,6 +1,7 @@
 import { DispatchableEvent, emit, hasListeners } from "../events";
 import { Logger, getLogger } from "../utils/logger";
 import { TaskChain, TaskResultStatus } from "./task-chain";
+import { now } from "../utils/time";
 
 export abstract class Task {
   get name(): string {
@@ -168,8 +169,7 @@ export abstract class Task {
       return -1;
     }
 
-    let timeForExpiration =
-      this._invocationEvent.expirationTimestamp - Date.now();
+    let timeForExpiration = this._invocationEvent.expirationTimestamp - now();
 
     if (this.outputEventNames.some(hasListeners)) {
       timeForExpiration *= 0.9;

--- a/src/internal/tasks/task.ts
+++ b/src/internal/tasks/task.ts
@@ -169,7 +169,7 @@ export abstract class Task {
     }
 
     let timeForExpiration =
-      this._invocationEvent.expirationTimestamp - new Date().getTime();
+      this._invocationEvent.expirationTimestamp - Date.now();
 
     if (this.outputEventNames.some(hasListeners)) {
       timeForExpiration *= 0.9;

--- a/src/internal/utils/time.ts
+++ b/src/internal/utils/time.ts
@@ -1,0 +1,9 @@
+import { android as androidApp } from "tns-core-modules/application/application";
+
+export function now(): number {
+  if (androidApp) {
+    return java.lang.System.currentTimeMillis();
+  } else {
+    return Math.round(NSDate.date().timeIntervalSince1970 * 1000.0);
+  }
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -114,6 +114,11 @@
 			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
 			"dev": true
 		},
+		"await-lock": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.0.1.tgz",
+			"integrity": "sha512-ntLi9fzlMT/vWjC1wwVI11/cSRJ3nTS35qVekNc9WnaoMOP2eWH0RvIqwLQkDjX4a4YynsKEv+Ere2VONp9wxg=="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -52,16 +52,17 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/GeoTecINIT/nativescript-task-dispatcher",
   "devDependencies": {
-    "tns-core-modules": "^6.0.0",
-    "tns-platform-declarations": "^6.0.0",
-    "typescript": "~3.4.5",
     "prompt": "^1.0.0",
     "rimraf": "^2.6.3",
+    "semver": "^5.6.0",
+    "tns-core-modules": "^6.0.0",
+    "tns-platform-declarations": "^6.0.0",
     "tslint": "^5.12.1",
-    "semver": "^5.6.0"
+    "typescript": "~3.4.5"
   },
   "dependencies": {
-    "@nano-sql/adapter-sqlite-nativescript": "^2.0.3"
+    "@nano-sql/adapter-sqlite-nativescript": "^2.0.3",
+    "await-lock": "^2.0.1"
   },
   "bootstrapper": "nativescript-plugin-seed"
 }


### PR DESCRIPTION
This pull request includes the following minor fixes:
* The Android alarm scheduler `schedule()` and `cancel()` methods now hold an execution lock to avoid concurrent executions which lead to unexpected scheduling behaviors.
* The task graph loader now prepares tasks sequentially instead of in parallel. In some scenarios two tasks could need the same things to be prepared (two tasks which require access to the location of the user, and hence, a location access permission to be granted). Previously this permission could end up being asked twice. With this fix, this situation will no longer happen.

Enhancements:
* Current time acquisition has been improved. Obtaining the current time no longer requires a Date object to be created, thus improving memory usage and gaining some nanoseconds in terms of accuracy. Moreover, whenever it has been possible current time acquisition has been replaced with native method calls. Short lived tests show some small improvements in terms of time accuracy. However, long-term tests become necessary in order to validate this hypothesis.