### PR TITLE
Replace NanoSQL with Couchbase Lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,19 +499,6 @@ The only (advised) way to create a ReadyRunnableTaskBuilder from within a TaskGr
 - **No support for foreground tasks in the middle of a task chain**. If one of your tasks requires foreground execution and depends on another task that does not require it, it will not be executed in the foreground. This happens because currently we do not back-propagate the foreground execution setting (but it is something planned). As a temporal fix, if a task could make a foreground task to be executed, declare the first task as a foreground task too.
 - **No support for event-driven foreground tasks** We have yet to evaluate if this is a common scenario. If you feel like this is a must-have functionality, please open an issue or comment on an existing one related to the topic. A quick workaround is to schedule the task in 1 minute by the time the event gets triggered.
 
-## Known issues
-
-### nanoSQL2
-
-If your application depends on [nanoSQL 2](https://www.npmjs.com/package/@nano-sql/adapter-sqlite-nativescript) for data persistence, you should check which database is in use (and change it, if applicable) before running a query against your database. You can do it as follows:
-
-```ts
-if (nSQL().selectedDB !== dbName) {
-  nSQL().useDatabase(dbName);
-}
-nSQL(tableName).query(...);
-```
-
 ## Plugin authors
 
 <a href="https://github.com/agonper" title="Alberto González Pérez">

--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -11,7 +11,7 @@
 
 android {
   defaultConfig {
-    minSdkVersion 17
+    minSdkVersion 19
     generatedDensities = []
   }
   aaptOptions {

--- a/demo/app/tests/internal/persistence/planned-tasks-store.ts
+++ b/demo/app/tests/internal/persistence/planned-tasks-store.ts
@@ -197,8 +197,8 @@ describe("Planned Tasks Store", () => {
 
         const cancellationEvents = await store.getAllCancelEvents();
         expect(cancellationEvents.length).toBe(2);
-        expect(cancellationEvents.indexOf("cancelEvent") !== -1);
-        expect(cancellationEvents.indexOf("otherEvent") !== -1);
+        expect(cancellationEvents.indexOf("cancelEvent")).not.toBe(-1);
+        expect(cancellationEvents.indexOf("otherEvent")).not.toBe(-1);
     });
 
     it("gets stored tasks with the same cancelEvent", async () => {

--- a/src/internal/persistence/planned-tasks-store.ts
+++ b/src/internal/persistence/planned-tasks-store.ts
@@ -7,7 +7,8 @@ import {
 } from "nativescript-couchbase-plugin";
 import { now } from "../utils/time";
 
-const DB_NAME = "td-planned-tasks";
+const DB_NAME = "task-dispatcher";
+const DOC_TYPE = "planned-task";
 
 export interface PlannedTasksStore {
   insert(plannedTask: PlannedTask): Promise<void>;
@@ -215,6 +216,7 @@ function documentFrom(plannedTask: PlannedTask): any {
   } = plannedTask;
 
   return {
+    type: DOC_TYPE,
     ...runnableTask,
     planningType,
     schedulerType,

--- a/src/internal/persistence/planned-tasks-store.ts
+++ b/src/internal/persistence/planned-tasks-store.ts
@@ -1,234 +1,13 @@
-import { NativeSQLite } from "@nano-sql/adapter-sqlite-nativescript";
-import { nSQL } from "@nano-sql/core/lib/index";
 import { PlannedTask, PlanningType } from "../tasks/planner/planned-task";
 import { RunnableTask } from "../tasks/runnable-task";
+import {
+  Couchbase,
+  QueryLogicalOperator,
+  QueryMeta,
+} from "nativescript-couchbase-plugin";
 import { now } from "../utils/time";
 
-const DB_NAME = "tasks-dispatcher";
-const PLANNED_TASKS_TABLE = "plannedTasks";
-
-class PlannedTaskDBStore implements PlannedTasksStore {
-  private dbInitialized: boolean = false;
-  private createDBProcedure: Promise<void>;
-
-  async insert(plannedTask: PlannedTask): Promise<void> {
-    const {
-      name,
-      startAt,
-      interval,
-      recurrent,
-      params,
-      cancelEvent,
-    } = plannedTask;
-
-    const runnableTask: RunnableTask = {
-      name,
-      startAt,
-      interval,
-      recurrent,
-      params,
-      cancelEvent,
-    };
-
-    const possibleTask = await this.get(runnableTask);
-    if (possibleTask) {
-      throw new PlannedTaskAlreadyExistsError(plannedTask);
-    }
-
-    const instance = await this.db();
-    await instance.query("upsert", { ...plannedTask }).exec();
-  }
-
-  async delete(taskId: string): Promise<void> {
-    const instance = await this.db();
-    await instance.query("delete").where(["id", "=", taskId]).exec();
-  }
-
-  async get(task: string | RunnableTask): Promise<PlannedTask> {
-    let whereStatement: Array<any> = ["id", "=", task];
-    if (typeof task !== "string") {
-      const runnableTask = task as RunnableTask;
-      whereStatement = [
-        ["name", "=", runnableTask.name],
-        "AND",
-        ["startAt", "=", runnableTask.startAt],
-        "AND",
-        ["interval", "=", runnableTask.interval],
-        "AND",
-        ["recurrent", "=", runnableTask.recurrent],
-      ];
-    }
-
-    const instance = await this.db();
-    nSQL(PLANNED_TASKS_TABLE).useDatabase(DB_NAME); // <- "Dark sourcery" (TM)
-    const rows = await instance.query("select").where(whereStatement).exec();
-    if (rows.length === 0) {
-      return null;
-    }
-
-    if (typeof task === "string") {
-      return this.plannedTaskFromRow(rows[0]);
-    }
-
-    const params = JSON.stringify(task.params);
-    for (let row of rows) {
-      if (params === JSON.stringify(row.params)) {
-        return this.plannedTaskFromRow(row);
-      }
-    }
-    return null;
-  }
-
-  async getAllSortedByNextRun(
-    planningType?: PlanningType
-  ): Promise<Array<PlannedTask>> {
-    const instance = await this.db();
-    let query = instance.query("select");
-    if (planningType) {
-      query = query.where(["planningType", "=", planningType]);
-    }
-
-    const rows = await query.exec();
-    const plannedTasks = rows.map((row) => this.plannedTaskFromRow(row));
-    const currentMillis = now();
-
-    return plannedTasks.sort(
-      (t1, t2) => t1.nextRun(currentMillis) - t2.nextRun(currentMillis)
-    );
-  }
-
-  async getAllCancelEvents(): Promise<Array<string>> {
-    const instance = await this.db();
-    const rows = await instance
-      .query("select")
-      .distinct(["cancelEvent"])
-      .exec();
-
-    return rows.map((row) => row.cancelEvent);
-  }
-
-  async getAllFilteredByCancelEvent(
-    cancelEvent: string
-  ): Promise<Array<PlannedTask>> {
-    const instance = await this.db();
-    const rows = await instance
-      .query("select")
-      .where(["cancelEvent", "=", cancelEvent])
-      .exec();
-
-    return rows.map((row) => this.plannedTaskFromRow(row));
-  }
-
-  async increaseErrorCount(taskId: string): Promise<void> {
-    const plannedTask = await this.get(taskId);
-
-    if (plannedTask) {
-      const instance = await this.db(`${PLANNED_TASKS_TABLE}.errorCount`);
-      await instance
-        .query("upsert", plannedTask.errorCount + 1)
-        .where(["id", "=", taskId])
-        .exec();
-    } else {
-      throw new Error(`Task not found: ${taskId}`);
-    }
-  }
-
-  async increaseTimeoutCount(taskId: string): Promise<void> {
-    const plannedTask = await this.get(taskId);
-
-    if (plannedTask) {
-      const instance = await this.db(`${PLANNED_TASKS_TABLE}.timeoutCount`);
-      await instance
-        .query("upsert", plannedTask.timeoutCount + 1)
-        .where(["id", "=", taskId])
-        .exec();
-    } else {
-      throw new Error(`Task not found: ${taskId}`);
-    }
-  }
-
-  async updateLastRun(taskId: string, timestamp: number): Promise<void> {
-    const plannedTask = await this.get(taskId);
-
-    if (plannedTask) {
-      const instance = await this.db(`${PLANNED_TASKS_TABLE}.lastRun`);
-      await instance
-        .query("upsert", timestamp)
-        .where(["id", "=", taskId])
-        .exec();
-    } else {
-      throw new Error(`Task not found: ${taskId}`);
-    }
-  }
-
-  async deleteAll(): Promise<void> {
-    const instance = await this.db();
-    await instance.query("delete").exec();
-  }
-
-  private async db(tableName = PLANNED_TASKS_TABLE) {
-    await this.createDB();
-    if (nSQL().selectedDB !== DB_NAME) {
-      nSQL().useDatabase(DB_NAME);
-    }
-    return nSQL(tableName);
-  }
-
-  // TODO: Extract to an isolated class
-  private async createDB() {
-    if (this.dbInitialized) {
-      return;
-    }
-    if (!this.createDBProcedure) {
-      this.createDBProcedure = nSQL().createDatabase({
-        id: DB_NAME,
-        mode: new NativeSQLite(),
-        tables: [
-          {
-            name: PLANNED_TASKS_TABLE,
-            model: {
-              "id:uuid": { pk: true },
-              "planningType:string": {},
-              "schedulerType:string": {},
-              "name:string": {},
-              "startAt:int": {},
-              "params:obj": {},
-              "interval:int": {},
-              "recurrent:boolean": {},
-              "createdAt:int": {},
-              "errorCount:int": {},
-              "timeoutCount:int": {},
-              "lastRun:int": {},
-              "cancelEvent:string": {},
-            },
-          },
-        ],
-      });
-    }
-    await this.createDBProcedure;
-    this.dbInitialized = true;
-  }
-
-  private plannedTaskFromRow(obj: any) {
-    return new PlannedTask(
-      obj.planningType,
-      obj.schedulerType,
-      {
-        name: obj.name,
-        startAt: obj.startAt,
-        interval: obj.interval,
-        recurrent: obj.recurrent,
-        params: obj.params,
-        cancelEvent: obj.cancelEvent,
-      },
-      obj.id,
-      obj.createdAt,
-      obj.lastRun,
-      obj.errorCount,
-      obj.timeoutCount
-    );
-  }
-}
+const DB_NAME = "td-planned-tasks";
 
 export interface PlannedTasksStore {
   insert(plannedTask: PlannedTask): Promise<void>;
@@ -242,6 +21,228 @@ export interface PlannedTasksStore {
   increaseErrorCount(taskId: string): Promise<void>;
   increaseTimeoutCount(taskId: string): Promise<void>;
   updateLastRun(taskId: string, timestamp: number): Promise<void>;
+}
+
+class PlannedTaskDBStore implements PlannedTasksStore {
+  private readonly database: Couchbase;
+
+  constructor() {
+    this.database = new Couchbase(DB_NAME);
+  }
+
+  async insert(plannedTask: PlannedTask): Promise<void> {
+    const runnableTask = runnableTaskFrom(plannedTask);
+
+    const possibleTask = await this.get(runnableTask);
+    if (possibleTask) {
+      throw new PlannedTaskAlreadyExistsError(plannedTask);
+    }
+
+    let doc = documentFrom(plannedTask);
+    this.database.createDocument(doc, plannedTask.id);
+  }
+
+  async delete(taskId: string): Promise<void> {
+    this.database.deleteDocument(taskId);
+  }
+
+  async get(task: string | RunnableTask): Promise<PlannedTask> {
+    if (typeof task === "string") {
+      const doc = this.database.getDocument(task);
+      return doc ? plannedTaskFrom(doc) : null;
+    }
+
+    const { name, startAt, interval, recurrent } = task;
+    const docs = this.database.query({
+      select: [],
+      where: [
+        { property: "name", comparison: "equalTo", value: name },
+        {
+          logical: QueryLogicalOperator.AND,
+          property: "startAt",
+          comparison: "equalTo",
+          value: startAt,
+        },
+        {
+          logical: QueryLogicalOperator.AND,
+          property: "interval",
+          comparison: "equalTo",
+          value: interval,
+        },
+        {
+          logical: QueryLogicalOperator.AND,
+          property: "recurrent",
+          comparison: "equalTo",
+          value: recurrent,
+        },
+      ],
+    });
+
+    if (docs.length === 0) {
+      return null;
+    }
+
+    const params = JSON.stringify(task.params);
+    for (let doc of docs) {
+      if (params === JSON.stringify(doc.params)) {
+        return plannedTaskFrom(doc);
+      }
+    }
+    return null;
+  }
+
+  async getAllSortedByNextRun(
+    planningType?: PlanningType
+  ): Promise<Array<PlannedTask>> {
+    const docs = this.database.query({
+      select: [],
+      where: planningType
+        ? [
+            {
+              property: "planningType",
+              comparison: "equalTo",
+              value: planningType,
+            },
+          ]
+        : undefined,
+    });
+
+    const plannedTasks = docs.map((doc) => plannedTaskFrom(doc));
+    const currentMillis = now();
+
+    return plannedTasks.sort(
+      (t1, t2) => t1.nextRun(currentMillis) - t2.nextRun(currentMillis)
+    );
+  }
+
+  async getAllCancelEvents(): Promise<Array<string>> {
+    const docs = this.database.query({ select: ["cancelEvent"] });
+
+    const cancelEvents = docs.map((doc) => doc.cancelEvent);
+    const cancelEventSet = new Set<string>(cancelEvents);
+    return [...cancelEventSet];
+  }
+
+  async getAllFilteredByCancelEvent(
+    cancelEvent: string
+  ): Promise<Array<PlannedTask>> {
+    const docs = this.database.query({
+      select: [],
+      where: [
+        { property: "cancelEvent", comparison: "equalTo", value: cancelEvent },
+      ],
+    });
+
+    return docs.map((doc) => plannedTaskFrom(doc));
+  }
+
+  async increaseErrorCount(taskId: string): Promise<void> {
+    const plannedTask = await this.get(taskId);
+
+    if (plannedTask) {
+      this.database.updateDocument(taskId, {
+        errorCount: plannedTask.errorCount + 1,
+      });
+    } else {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+  }
+
+  async increaseTimeoutCount(taskId: string): Promise<void> {
+    const plannedTask = await this.get(taskId);
+
+    if (plannedTask) {
+      this.database.updateDocument(taskId, {
+        timeoutCount: plannedTask.timeoutCount + 1,
+      });
+    } else {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+  }
+
+  async updateLastRun(taskId: string, timestamp: number): Promise<void> {
+    const plannedTask = await this.get(taskId);
+
+    if (plannedTask) {
+      this.database.updateDocument(taskId, {
+        lastRun: timestamp,
+      });
+    } else {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+  }
+
+  deleteAll(): Promise<void> {
+    return new Promise((resolve) => {
+      const docs = this.database.query({ select: [QueryMeta.ID] });
+      for (let doc of docs) {
+        this.database.deleteDocument(doc.id);
+      }
+      resolve();
+    });
+  }
+}
+
+function runnableTaskFrom(plannedTask: PlannedTask): RunnableTask {
+  const {
+    name,
+    startAt,
+    interval,
+    recurrent,
+    params,
+    cancelEvent,
+  } = plannedTask;
+
+  return {
+    name,
+    startAt,
+    interval,
+    recurrent,
+    params,
+    cancelEvent,
+  };
+}
+
+function documentFrom(plannedTask: PlannedTask): any {
+  const runnableTask = runnableTaskFrom(plannedTask);
+  const {
+    planningType,
+    schedulerType,
+    createdAt,
+    lastRun,
+    errorCount,
+    timeoutCount,
+  } = plannedTask;
+
+  return {
+    ...runnableTask,
+    planningType,
+    schedulerType,
+    createdAt,
+    lastRun,
+    errorCount,
+    timeoutCount,
+  };
+}
+
+function plannedTaskFrom(doc: any) {
+  return new PlannedTask(
+    doc.planningType,
+    doc.schedulerType,
+    {
+      name: doc.name,
+      startAt: doc.startAt,
+      interval: doc.interval,
+      recurrent: doc.recurrent,
+      params: doc.params,
+      cancelEvent: doc.cancelEvent,
+    },
+    doc.id,
+    doc.createdAt,
+    doc.lastRun,
+    doc.errorCount,
+    doc.timeoutCount
+  );
 }
 
 export const plannedTasksDB = new PlannedTaskDBStore();

--- a/src/internal/persistence/planned-tasks-store.ts
+++ b/src/internal/persistence/planned-tasks-store.ts
@@ -216,7 +216,7 @@ function documentFrom(plannedTask: PlannedTask): any {
   } = plannedTask;
 
   return {
-    type: DOC_TYPE,
+    docType: DOC_TYPE,
     ...runnableTask,
     planningType,
     schedulerType,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -460,6 +460,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nativescript-couchbase-plugin": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/nativescript-couchbase-plugin/-/nativescript-couchbase-plugin-0.9.6.tgz",
+      "integrity": "sha512-kMA9KHQX82TFaGnGUhY94KLOLss4pb5QmghgoEdu1sLwd94I/f1MQ+kHWbuBOdFmdQJw5oCK+Sey+A22Nd5jgA=="
+    },
     "nativescript-hook": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/nativescript-hook/-/nativescript-hook-0.2.5.tgz",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -30,29 +30,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@nano-sql/adapter-sqlite-nativescript": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nano-sql/adapter-sqlite-nativescript/-/adapter-sqlite-nativescript-2.0.3.tgz",
-      "integrity": "sha512-fiR9C55wXjqpUZipKH+0LCUO+d4k8W9JpfnlbGELbP/6sqsKAfzLb1aiUjf6kqLycX2wU1f9Zazt9ikJekyl0Q==",
-      "requires": {
-        "@nano-sql/core": "^2.3.2",
-        "nativescript-sqlite": "^2.3.3"
-      }
-    },
-    "@nano-sql/core": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@nano-sql/core/-/core-2.3.7.tgz",
-      "integrity": "sha512-B9nniPPRhPf5Hf2cyvy72SNEg4iKQEW6pig9nwrM4DJlmOMZudifOMPBoJuK6JcTaLATIOGRPkclfosNUALnLQ==",
-      "requires": {
-        "chalk": "^2.4.2",
-        "chokidar": "^3.0.2",
-        "command-line-args": "^5.1.1",
-        "fast-deep-equal": "^2.0.1",
-        "levenshtein-edit-distance": "^2.0.4",
-        "really-small-events": "^1.1.0",
-        "snap-db": "^1.1.1"
-      }
-    },
     "@nativescript/core": {
       "version": "6.5.18",
       "resolved": "https://registry.npmjs.org/@nativescript/core/-/core-6.5.18.tgz",
@@ -79,18 +56,9 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-      "optional": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -101,12 +69,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "optional": true
     },
     "async": {
       "version": "0.9.2",
@@ -125,12 +87,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
-      "optional": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -139,15 +95,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "optional": true,
-      "requires": {
-        "fill-range": "^7.0.1"
       }
     },
     "builtin-modules": {
@@ -160,32 +107,18 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
     },
-    "chokidar": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-      "optional": true,
-      "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -193,25 +126,14 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
-    },
-    "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "optional": true,
-      "requires": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      }
     },
     "commander": {
       "version": "2.20.3",
@@ -262,7 +184,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
@@ -276,40 +199,11 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "optional": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "optional": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "optional": true
     },
     "glob": {
       "version": "7.1.6",
@@ -325,19 +219,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-      "optional": true,
-      "requires": {
-        "is-glob": "^4.0.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "i": {
       "version": "0.3.6",
@@ -361,36 +247,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "optional": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "optional": true
-    },
-    "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "optional": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "optional": true
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -412,17 +268,6 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
-    },
-    "levenshtein-edit-distance": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-2.0.5.tgz",
-      "integrity": "sha512-Yuraz7QnMX/JENJU1HA6UtdsbhRzoSFnGpVGVryjQgHtl2s/YmVgmNYkVs5yzVZ9aAvQR9wPBUH3lG755ylxGA=="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "optional": true
     },
     "mdn-data": {
       "version": "2.0.6",
@@ -490,22 +335,11 @@
         }
       }
     },
-    "nativescript-sqlite": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/nativescript-sqlite/-/nativescript-sqlite-2.6.4.tgz",
-      "integrity": "sha512-y8uHnvZ4/pH68UjKjeZ1VQHgjp/Ly+/J59ydg7/QV/NjAhhxqWnByJjLT2VT1aY6wb/7p+/3xStWKkHlNPrAqw=="
-    },
     "ncp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
       "dev": true
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "optional": true
     },
     "once": {
       "version": "1.4.0",
@@ -527,12 +361,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
-    },
-    "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "optional": true
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -576,20 +404,6 @@
       "requires": {
         "mute-stream": "~0.0.4"
       }
-    },
-    "readdirp": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
-      "optional": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
-    "really-small-events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/really-small-events/-/really-small-events-1.1.0.tgz",
-      "integrity": "sha512-iyh4pULyDYBMecekEYcP3ToJD3ZUdIPfZV9nx1C1lJfMguElkDAZvEMJegy8uE7eIROCuLsqh5r44fVro9nKFg=="
     },
     "reduce-css-calc": {
       "version": "2.1.7",
@@ -644,11 +458,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "snap-db": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/snap-db/-/snap-db-1.1.6.tgz",
-      "integrity": "sha512-KxsO5RnY70J48f6poy0qVm2WS8ZbqG0PUVP2fjd7dvlaCMZ/DxtDv5fhhIVwkP2lOmNQ9QsTFfDuCA7N+TF3qg=="
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -671,6 +480,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -695,15 +505,6 @@
       "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-6.5.15.tgz",
       "integrity": "sha512-gCUt2rjPTndp0K6xrgo6tFJvmkAsVOnIvebUUXMdLsNrJScs+OX4pL4DeIGMHGm/ciLqBlG5ZPkTOi8ZJCZuAQ==",
       "dev": true
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "optional": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -746,12 +547,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
-    },
-    "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "optional": true
     },
     "utile": {
       "version": "0.3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@nano-sql/adapter-sqlite-nativescript": "^2.0.3",
     "await-lock": "^2.0.1",
+    "nativescript-couchbase-plugin": "^0.9.6",
     "serialize-javascript": "^5.0.1"
   },
   "bootstrapper": "nativescript-plugin-seed"

--- a/src/package.json
+++ b/src/package.json
@@ -61,7 +61,6 @@
     "typescript": "~3.4.5"
   },
   "dependencies": {
-    "@nano-sql/adapter-sqlite-nativescript": "^2.0.3",
     "await-lock": "^2.0.1",
     "nativescript-couchbase-plugin": "^0.9.6",
     "serialize-javascript": "^5.0.1"


### PR DESCRIPTION
Due to its singleton nature, it becomes difficult to synchronise DB access (more concretely, NanoSQL usage) across multiple plugins. This becomes even harder when running code alternatively, due to scatter async calls.

After evaluating multiple alternatives like:
- [https://github.com/nathanaela/nativescript-sqlite](https://github.com/nathanaela/nativescript-sqlite)
- [https://github.com/juanchinovas/nativescript-sqlite-access](https://github.com/juanchinovas/nativescript-sqlite-access)
- [https://github.com/couchbaselabs/nativescript-couchbase](https://github.com/couchbaselabs/nativescript-couchbase)
- [https://github.com/triniwiz/nativescript-couchbase-plugin](https://github.com/triniwiz/nativescript-couchbase-plugin)

Among the previous list, the last one seems the best maintained one, with more contributors and recent answers to issues. Moreover, it fits well the current usage of the plugin DB and the main author is part of the NativeScript team.

This PR does not induce any code breaking changes. However, any app running in production should cope with having all its scheduled tasks removed after the update. So **the application task graph must be reconstructed after this PR becomes merged and its code gets released.**