### PR TITLE
Fix wakelock acquisition & notification strings configuration and usage

### DIFF
--- a/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/event-driven/android/runner-service.android.ts
@@ -34,6 +34,9 @@ export class TaskChainRunnerService
     this.nativeService = nativeService;
 
     this.wakeLock = taskChainRunnerWakeLock(nativeService);
+    this.wakeLock.setReferenceCounted(false);
+    this.wakeLock.acquire();
+
     this.timeoutIds = new Set();
     this.taskChainCount = 0;
     this.killed = false;

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
@@ -54,6 +54,9 @@ export class AlarmRunnerService
     this.inForeground = false;
 
     this.wakeLock = alarmRunnerWakeLock(nativeService);
+    this.wakeLock.acquire();
+    this.wakeLock.setReferenceCounted(false);
+
     this.taskStore = plannedTasksDB;
     this.foregroundChecker = new ForegroundChecker();
 


### PR DESCRIPTION
This PR is aimed to fix two important issues:
- On certain devices the execution window available for a broadcast receiver before CPU enters into sleep mode is smaller than the standard (10 seconds). Now energy wakelock is acquired earlier, thus overcoming this problem.
- Foreground notification texts were forced to be included in `strings.xml` even for those applications not executing foreground tasks. Now, notification channel setup functionality skip those channels for which notification texts hadn't been set. In addition, the error message has been improved when trying to create a notification for an unconfigured channel (with missing strings).