### PR TITLE
Fix alarm cancel task triggered by same alarm

### DIFF
--- a/src/internal/tasks/runners/last-recurrent-run.ts
+++ b/src/internal/tasks/runners/last-recurrent-run.ts
@@ -1,0 +1,18 @@
+import { now } from "../../utils/time";
+
+class LastRecurrentRun {
+  private lastRun: number;
+
+  updateLast() {
+    this.lastRun = now();
+  }
+
+  timeSince() {
+    if (typeof this.lastRun === "undefined") {
+      return 0;
+    }
+    return now() - this.lastRun;
+  }
+}
+
+export const lastRecurrentRun = new LastRecurrentRun();

--- a/src/internal/tasks/runners/single-task-runner.ts
+++ b/src/internal/tasks/runners/single-task-runner.ts
@@ -27,7 +27,6 @@ export class SingleTaskRunner {
       ? lastRecurrentRun.timeSince()
       : 0;
 
-    this.logger.debug(`Time from trigger until execution: ${lastRunOffset}`);
     await this.taskStore.updateLastRun(id, now() - lastRunOffset);
 
     try {

--- a/src/internal/tasks/runners/single-task-runner.ts
+++ b/src/internal/tasks/runners/single-task-runner.ts
@@ -5,6 +5,7 @@ import { Task, TaskParams } from "../task";
 import { DispatchableEvent, on, TaskDispatcherEvent, off } from "../../events";
 import { Logger, getLogger } from "../../utils/logger";
 import { now } from "../../utils/time";
+import { lastRecurrentRun } from "./last-recurrent-run";
 
 const FAILURE_THRESHOLD = 3;
 
@@ -22,7 +23,12 @@ export class SingleTaskRunner {
     const { name, id, params } = plannedTask;
     const task = getTask(name);
 
-    await this.taskStore.updateLastRun(id, now());
+    const lastRunOffset = plannedTask.recurrent
+      ? lastRecurrentRun.timeSince()
+      : 0;
+
+    this.logger.debug(`Time from trigger until execution: ${lastRunOffset}`);
+    await this.taskStore.updateLastRun(id, now() - lastRunOffset);
 
     try {
       const parameterizedTask = new ParameterizedTask(task, params, startEvent);

--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/receiver.android.ts
@@ -7,8 +7,9 @@ import { createAlarmRunnerServiceIntent } from "../../intents.android";
 import { PlanningType } from "../../../../../planner/planned-task";
 import { Logger, getLogger } from "../../../../../../utils/logger";
 import { now } from "../../../../../../utils/time";
+import { lastRecurrentRun } from "../../../../../runners/last-recurrent-run";
 
-const MIN_INTERVAL = 60000;
+const MIN_INTERVAL = 59000;
 
 export class AlarmReceiver
   implements es.uji.geotec.taskdispatcher.alarms.AlarmReceiverDelegate {
@@ -20,6 +21,7 @@ export class AlarmReceiver
   private logger: Logger;
 
   onReceive(context: android.content.Context, intent: android.content.Intent) {
+    lastRecurrentRun.updateLast();
     this.logger = getLogger("AlarmReceiver");
     this.logger.info("Alarm triggered");
 


### PR DESCRIPTION
This PR fixes the following issue:
- Sometimes, two alarms are running with different intervals which co-occur once every x runs. When one of the two tasks needed to be cancelled just before the next co-ocurring execution window the alarm was rescheduled, when it didn't need too, thus delaying other task's execution.

> @matey97, I touched critical code parts while solving this issue. I would greatly appreciate if you can think of any scenarios where this code logic would fail. Thanks