### PR TITLE
Sticky notification icon conforming to nativescript-local-notifications defaults

### DIFF
--- a/src/internal/tasks/schedulers/time-based/android/notification-manager.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/notification-manager.android.ts
@@ -129,7 +129,7 @@ function createStringFetcher(context: android.content.Context) {
 function createIconFetcher(context: android.content.Context) {
   const getDrawableId = createDrawableIdFetcher(context);
   return (key?: string): number => {
-    let icon: number;
+    let icon = 0;
     if (key && key.indexOf(Utils.RESOURCE_PREFIX) === 0) {
       icon = getDrawableId(key.substr(Utils.RESOURCE_PREFIX.length));
     }


### PR DESCRIPTION
This PR improves the display of the sticky notification while the alarm service is running in foreground, concretely it allows some degree of customisation in its icon:
- If Android version is 5 or above, it will search for a drawable named: ic_stat_notify_silhouette.
- If that condition is not met or the drawable does no exist, it will try to use a drawable named: ic_stat_notify.
- Otherwise, it will use the app icon as it was doing before.

By doing this, the behaviour of the notification defaults become aligned with the defaults of Eddy Verbruggen's local-notifications-plugin.