### PR TITLE
Fix application settings timestamps

### DIFF
--- a/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
+++ b/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
@@ -1,18 +1,17 @@
 import { ApplicationSettings } from "@nativescript/core";
 import { now } from "../../../utils/time";
 
-const PREVIOUS_PLANNING_TIMESTAMP = "PREVIOUS_PLANNING_TIMESTAMP";
-const CURRENT_PLANNING_TIMESTAMP = "CURRENT_PLANNING_TIMESTAMP";
+const PLANNING_TIMESTAMPS = "PLANNING_TIMESTAMPS";
 
 class PlanningTimestamp {
-  private _previous: number = this.getNumber(
-    PREVIOUS_PLANNING_TIMESTAMP,
-    -1
-  );
-  private _current: number = this.getNumber(
-    CURRENT_PLANNING_TIMESTAMP,
-    -1
-  );
+  private _previous: number;
+  private _current: number;
+
+  constructor() {
+    const timestamps = this.getTimestamps();
+    this._previous = timestamps.previous;
+    this._current = timestamps.current;
+  }
 
   get previous(): number {
     return this._previous;
@@ -27,20 +26,33 @@ class PlanningTimestamp {
     const newCurrent = now();
     this._previous = previousCurrent;
     this._current = newCurrent;
-    this.setNumber(PREVIOUS_PLANNING_TIMESTAMP, previousCurrent);
-    this.setNumber(CURRENT_PLANNING_TIMESTAMP, newCurrent);
+    this.setTimestamps({ previous: this.previous, current: this.current });
   }
 
-  private getNumber(key: string, defaultValue: number): number {
-    const stringValue = ApplicationSettings.getString(key, null);
+  private getTimestamps(): Timestamps {
+    const stringifiedTimestamps = ApplicationSettings.getString(PLANNING_TIMESTAMPS, undefined);
 
-    return stringValue !== null ? parseInt(stringValue) : defaultValue;
+    if (!stringifiedTimestamps) {
+      return {
+        previous: -1,
+        current: -1
+      };
+    }
+
+    return JSON.parse(stringifiedTimestamps);
   }
 
-  private setNumber(key: string, value: number): void {
-    ApplicationSettings.setString(key, value.toString());
+  private setTimestamps(timestamps: Timestamps): void {
+    const stringifiedTimestamps = JSON.stringify(timestamps);
+
+    ApplicationSettings.setString(PLANNING_TIMESTAMPS, stringifiedTimestamps);
     ApplicationSettings.flush();
   }
+}
+
+interface Timestamps {
+  previous: number;
+  current: number;
 }
 
 export const planningTimestamp = new PlanningTimestamp();

--- a/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
+++ b/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
@@ -34,7 +34,7 @@ class PlanningTimestamp {
   private getNumber(key: string, defaultValue: number): number {
     const stringValue = ApplicationSettings.getString(key, null);
 
-    return stringValue !== null ? parseFloat(stringValue) : defaultValue;
+    return stringValue !== null ? parseInt(stringValue) : defaultValue;
   }
 
   private setNumber(key: string, value: number): void {

--- a/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
+++ b/src/internal/tasks/schedulers/time-based/planning-timestamp.ts
@@ -5,11 +5,11 @@ const PREVIOUS_PLANNING_TIMESTAMP = "PREVIOUS_PLANNING_TIMESTAMP";
 const CURRENT_PLANNING_TIMESTAMP = "CURRENT_PLANNING_TIMESTAMP";
 
 class PlanningTimestamp {
-  private _previous: number = ApplicationSettings.getNumber(
+  private _previous: number = this.getNumber(
     PREVIOUS_PLANNING_TIMESTAMP,
     -1
   );
-  private _current: number = ApplicationSettings.getNumber(
+  private _current: number = this.getNumber(
     CURRENT_PLANNING_TIMESTAMP,
     -1
   );
@@ -27,8 +27,18 @@ class PlanningTimestamp {
     const newCurrent = now();
     this._previous = previousCurrent;
     this._current = newCurrent;
-    ApplicationSettings.setNumber(PREVIOUS_PLANNING_TIMESTAMP, previousCurrent);
-    ApplicationSettings.setNumber(CURRENT_PLANNING_TIMESTAMP, newCurrent);
+    this.setNumber(PREVIOUS_PLANNING_TIMESTAMP, previousCurrent);
+    this.setNumber(CURRENT_PLANNING_TIMESTAMP, newCurrent);
+  }
+
+  private getNumber(key: string, defaultValue: number): number {
+    const stringValue = ApplicationSettings.getString(key, null);
+
+    return stringValue !== null ? parseFloat(stringValue) : defaultValue;
+  }
+
+  private setNumber(key: string, value: number): void {
+    ApplicationSettings.setString(key, value.toString());
     ApplicationSettings.flush();
   }
 }


### PR DESCRIPTION
This PR fixes a bug while storing planning timestamps on `ApplicationSettings`. The timestamps were stored using the `setNumber` method which, internally, for Android parses the number (i.e., timestamp) to a `float` type an storing the value in scientific notation losing precision on the last decimals. To fix the issue, the timestamps are now stored as `strings`.