### PR TITLE
fix: alarm-based task execution timeouts are no longer top-unbounded

### DIFF
--- a/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
+++ b/src/internal/tasks/schedulers/time-based/android/alarms/alarm/runner-service.android.ts
@@ -23,6 +23,7 @@ import { now } from "../../../../../../utils/time";
 import { ForegroundChecker } from "../../../../../foreground-checker";
 
 const MIN_TIMEOUT = 60000;
+const MAX_TIMEOUT = 180000;
 const TIMEOUT_EVENT_OFFSET = 5000;
 
 export class AlarmRunnerService
@@ -193,7 +194,7 @@ export class AlarmRunnerService
   private async calculateTimeout(taskPlanner: TaskManager) {
     const nextExecutionTime = await taskPlanner.nextInterval();
 
-    return Math.max(nextExecutionTime, MIN_TIMEOUT);
+    return Math.min(Math.max(nextExecutionTime, MIN_TIMEOUT), MAX_TIMEOUT);
   }
 
   private getExpirationTimestamp(timeout: number): number {


### PR DESCRIPTION
Closes #47 

This solves the problem when alarm intervals are relatively high (10+ min) and a task gets stuck running. 

Tasks executed by an alarm will have now between 1 to 3 minutes to complete their execution, making the alarm-based runner consistent with the event-based runner.

---
To plugin's users reading this: Why not keep the task execution unbounded? Android does not like long running services. By limiting the maximum time a task can be running we reduce the chances of Android killing the task execution service. If you need a long running process, run the task on a recurrent basis instead and save its progress at the end of the execution in order to continue the task in subsequent executions.

